### PR TITLE
chore: Bump Python and SCADE versions

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -37,10 +37,10 @@ jobs:
       library-name: "ansys-scade-wux"
       repository-name: "ansys/scade-wux"
       is-public: true
-      python-tests-versions: "['3.10']"
       main-python-version: '3.14'
       # 3.7 can't be built anymore
       build-wheelhouse-versions: "['3.10', '3.12']"
+      scade-tests-versions: "['23.1', '25.2', '26.1']"
     secrets:
       PYANSYS_CI_BOT_TOKEN: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
       PYANSYS_CI_BOT_USERNAME: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -13,7 +13,6 @@ on:
   workflow_dispatch:
 
 env:
-  MAIN_PYTHON_VERSION: '3.10'
   DOCUMENTATION_CNAME: 'wux.scade.docs.pyansys.com'
   LIBRARY_NAME: 'ansys-scade-wux'
 
@@ -38,10 +37,10 @@ jobs:
       library-name: "ansys-scade-wux"
       repository-name: "ansys/scade-wux"
       is-public: true
-      main-python-version: '3.12'
       # strategies
       build-wheelhouse-versions: "['3.10']"
       python-tests-versions: "['3.10']"
+      main-python-version: '3.14'
     secrets:
       PYANSYS_CI_BOT_TOKEN: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
       PYANSYS_CI_BOT_USERNAME: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -37,10 +37,10 @@ jobs:
       library-name: "ansys-scade-wux"
       repository-name: "ansys/scade-wux"
       is-public: true
-      # strategies
-      build-wheelhouse-versions: "['3.10']"
       python-tests-versions: "['3.10']"
       main-python-version: '3.14'
+      # 3.7 can't be built anymore
+      build-wheelhouse-versions: "['3.10', '3.12']"
     secrets:
       PYANSYS_CI_BOT_TOKEN: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
       PYANSYS_CI_BOT_USERNAME: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,8 @@ The ``ansys-scade-wux`` package supports only the versions of Python delivered w
 Ansys SCADE, starting from 2021 R2:
 
 * 2021 R2 through 2023 R1: Python 3.7
-* 2023 R2 and later: Python 3.10
+* 2023 R2 through 2025 R2: Python 3.10
+* 2026 R1 and later: Python 3.12
 
 Ansys SCADE Wrapper Tools has two installation modes: user and developer. To install for use,
 see `Getting started <https://wux.scade.docs.pyansys.com/version/stable/getting-started/index.html>`_.

--- a/doc/changelog.d/58.maintenance.md
+++ b/doc/changelog.d/58.maintenance.md
@@ -1,0 +1,1 @@
+Bump Python and SCADE versions

--- a/doc/source/getting-started/index.rst
+++ b/doc/source/getting-started/index.rst
@@ -9,9 +9,11 @@ page on the Ansys website.
 Requirements
 ------------
 The ``ansys-scade-wux`` package supports only the versions of Python delivered with
-Ansys SCADE, starting from 2023 R2:
+Ansys SCADE, starting from 2021 R2:
 
-* 2023 R2 and later: Python 3.10
+* 2021 R2 through 2023 R1: Python 3.7
+* 2023 R2 through 2025 R2: Python 3.10
+* 2026 R1 and later: Python 3.12
 
 Install in user mode
 --------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<3.13"]
+requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
@@ -8,8 +8,8 @@ version="2.1.dev0"
 description ="Generic code integration target for SCADE."
 readme="README.rst"
 
-# only 3.7. and 3.10
-requires-python = ">=3.7,!=3.8.*,!=3.9.*,<3.11"
+# only 3.7, 3.10, or >= 3.12
+requires-python = ">=3.7,!=3.8.*,!=3.9.*,!=3.11.*"
 license = {file = "LICENSE"}
 authors = [
     {name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"},
@@ -20,11 +20,16 @@ maintainers = [
 dependencies=[
     "importlib-metadata >= 1.0; python_version < '3.8'",
     "importlib-metadata >= 4.0; python_version >= '3.8'",
-    "ansys-scade-apitools",
+    "ansys-scade-apitools>=0.5.0",
 ]
 classifiers=[
     "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Topic :: Software Development :: Embedded Systems",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: Microsoft :: Windows",
 ]
@@ -36,9 +41,10 @@ build = [
     "twine==6.2.0"
 ]
 tests = [
-    # 8.0.2 at most: https://github.com/microsoft/PTVS/issues/7853
-    "pytest==8.4.2",
-    "pytest-cov==7.0.0"
+    "pytest >= 9.0.1; python_version >= '3.8'",
+    "pytest <= 7.4.4; python_version < '3.8'",
+    "pytest-cov >= 6.0.0; python_version >= '3.8'",
+    "pytest-cov <= 4.1.0; python_version < '3.8'",
 ]
 doc = [
     "ansys-sphinx-theme[autoapi]==1.7.0; python_version >= '3.12'",

--- a/tox.ini
+++ b/tox.ini
@@ -1,37 +1,45 @@
 [tox]
 description = Default tox environments list
-envlist = style, py{310}-{default,coverage}, doc-html
+# coverage is optional but includes tests: by default run only coverage
+# env_list = code-style, tests{-coverage,}-{py37,py310,py312}, doc-{links,html}
+env_list = code-style, tests-coverage-{py37,py310,py312}, doc-{links,html}
 skip_missing_interpreters = true
-isolated_build = true
 isolated_build_env = build
 
-[gh-actions]
-description = The tox environment to be executed in gh-actions for a given python version
-python =
-    3.10: style, py310-coverage, doc
-
+# [testenv:tests{-coverage,}-{py37,py310,py312}]
 [testenv]
-description = Checks for project unit tests and coverage (if desired)
+description =
+    Checks for project unit tests
+    coverage: and coverage
+    py37: with python version 3.7
+    py310: with python version 3.10
+    py312: with python version 3.12
 extras = tests
-setenv =
+set_env =
+    TEMP = {env_tmp_dir}
+    TMP = {env_tmp_dir}
     PYTHONUNBUFFERED = yes
-    coverage: PYTEST_EXTRA_ARGS = --cov=ansys.scade --cov-report=term --cov-report=xml:.cov/xml --cov-report=html:.cov/html --cov-branch
+    coverage: PYTEST_EXTRA_ARGS = --cov=ansys.scade.wux --cov-report=term --cov-report=xml:.cov/.{env_name}/xml --cov-report=html:.cov/.{env_name}/html --cov-branch
+pass_env =
+    ANSYSLMD_LICENSE_FILE
 commands =
-    pytest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
+    python -m pytest -o addopts={env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
 
-[testenv:style]
+[testenv:code-style]
 description = Checks project code style
 skip_install = true
 deps = pre-commit
 commands =
-    pre-commit install
     pre-commit run --all-files --show-diff-on-failure
 
 [testenv:doc-{links,html}]
-description = Check if documentation links generate properly
+description =
+    Checks
+    links: the integrity of all external links
+    html: if html documentation generates properly
 extras = doc
-setenv =
-    links: SPHINXBUILDER = linkcheck
-    html: SPHINXBUILDER = html
+set_env =
+    links: BUILDER = linkcheck
+    html: BUILDER = html
 commands =
-    sphinx-build -d "{toxworkdir}/doc_doctree" doc/source "{toxinidir}/doc/_build/{env:SPHINXBUILDER}" --color -vW -b{env:SPHINXBUILDER}
+    sphinx-build -d "{work_dir}/doc_doctree" doc/source "{tox_root}/doc/_build/{env:BUILDER}" --color -vW -b{env:BUILDER} -j auto --keep-going


### PR DESCRIPTION
Bump versions:

* Main Python version: 3.14 (fixes #57 )
* SCADE: 2026 R1
* Wheelhouse: Python 3.10, and 3.12